### PR TITLE
fix(security): Update five high-severity vulnerabilities

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-package-lock = false
+package-lock = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bitly-node-api (Bitly Node Rest API)
 
-[![Build Status](https://travis-ci.org/vijaypatoliya/bitly-node-api.svg?branch=master)](https://travis-ci.org/vijaypatoliya/bitly-node-api) [![Stackoverflow Thread](https://img.shields.io/badge/stackoverflow-bitly--node--api-yellowgreen.svg)](https://stackoverflow.com/search?q=nodejs-bitly-node-api)
+[![Stackoverflow Thread](https://img.shields.io/badge/stackoverflow-bitly--node--api-yellowgreen.svg)](https://stackoverflow.com/search?q=nodejs-bitly-node-api)
 
 This API supported Bitly standard REST API that accepts/returns JSON requests. Here is the [API reference](https://dev.bitly.com/v4_documentation.html)
 

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "debug": "^4.1.0",
     "iconv-lite": "^0.4.24",
     "lodash": "^4.17.11",
-    "mocha": "^5.2.0",
+    "mocha": "^11.7.1",
     "qs": "^6.6.0",
-    "xml2js": "^0.4.19"
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "jshint": "^2.9.7"


### PR DESCRIPTION
1. Update 5 vulnerabilities
<img width="1174" alt="截圖 2025-07-06 22 41 13" src="https://github.com/user-attachments/assets/477584dd-a34b-43e7-9df1-dd5952ea46ed" />

2. Remove travis CI status icon which is not supported now.
3. Switch package-lock to true.